### PR TITLE
Nextcloud 11 ready Raspbian image

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Contributions *very welcome* but first see [Contributing](#contributing)
 - [resinOS](https://resinos.io) - open source OS to run Docker containers on embedded devices that's been designed for reliability and proven in production.
 - [Fedora](https://fedoraproject.org/wiki/Raspberry_Pi#Preparing_the_SD_card) - Linux Fedora distribution built for the Pi. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)
 - [motionEyeOS](https://github.com/ccrisan/motioneyeos/wiki) - Linux distribution that turns a single-board computer into a video surveillance system.
-- [NextCloudPi](https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/) - Nextcloud ready image based on Raspbian.
+- [NextCloudPi](https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/) - Nextcloud ready image based on Raspbian. Features Nextcloud 11 running on Raspbian 8, with PHP 7 and HTTP2 enabled Apache server.
 
 ## Tools
 - [PiBakery](http://www.pibakery.org/) - The blocks based, easy to use setup tool for Raspberry Pi.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Contributions *very welcome* but first see [Contributing](#contributing)
 - [resinOS](https://resinos.io) - open source OS to run Docker containers on embedded devices that's been designed for reliability and proven in production.
 - [Fedora](https://fedoraproject.org/wiki/Raspberry_Pi#Preparing_the_SD_card) - Linux Fedora distribution built for the Pi. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)
 - [motionEyeOS](https://github.com/ccrisan/motioneyeos/wiki) - Linux distribution that turns a single-board computer into a video surveillance system.
+- [NextCloudPi](https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/) - Nextcloud ready image based on Raspbian.
 
 ## Tools
 - [PiBakery](http://www.pibakery.org/) - The blocks based, easy to use setup tool for Raspberry Pi.


### PR DESCRIPTION
This is a ready to use Nextcloud 11 for Raspberry Pi image based on Debian 8, HTTP2, and PHP7

# Please make sure all below checkboxes have been checked before submitting your PR.

- [x] I have read and understood the [contribution guidelines](https://github.com/thibmaek/awesome-raspberrypi/blob/master/CONTRIBUTING.md).
- [x] This pull request has a descriptive title. *(For example: `Add Raspbian`)*
- The topic I added
	- [x] includes a valid (https) link,
	- [x] includes a concise and on-topic description,
	- [x] mentions if there is only support some devices,
	- [x] is not a duplicate,
	- [x] has been added at the bottom of the appropriate category,
	- [x] is in the form of **Named Link - Description, seperated by commas.**
	- [x] ends with a dot.
