### PR TITLE
Added FistBump Repos to Projects List

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [pi_payments](https://github.com/anshulahuja98/pi_payments) - Payment module based on RFID.
 - [RaspiBolt](https://github.com/Stadicus/guides/tree/master/raspibolt) - Beginner’s Guide to ️⚡Lightning️⚡ on a Raspberry Pi.
 - [RaspiBlitz](https://github.com/rootzoll/raspiblitz) - Fastest and cheapest way to get your own Lightning Node running.
+- [FistBump Original](https://github.com/eliddell1/FistBump) - Handheld WPA Hash Grabbing Device - proof of concept
+- [FistBump BLE Edition](https://github.com/eliddell1/Project-Blue-Fist/blob/master/README.md) - WPA Hash Grabbing Bluetooth Peripheral / Android App
 
 ## Resources
 


### PR DESCRIPTION
Added link to two FistBump Projects.  FistBump is a device for grabbing WPA 4 way handshakes and PMKID hashes for Network Password Strength/Security Auditing.

# Please make sure all below checkboxes have been checked before submitting your PR.
<!-- IMPORTANT:
  If you can check some boxes, please submit your PR first and then
  tick the boxes in the PR description. Don't place x'es in the square brackets [] directly.
  Thank you ✨
-->

- [x ] I have read and understood the [contribution guidelines](https://github.com/thibmaek/awesome-raspberrypi/blob/master/CONTRIBUTING.md).
- [x ] This pull request has a descriptive title. *(For example: `Add Raspbian`)*
- The topic I added
	- [ x] includes a valid (https) link,
	- [x ] includes a concise and on-topic description,
	- [ x] mentions if there is only support some devices,
	- [ x] is not a duplicate,
	- [ ] has been added at the bottom of the appropriate category,
	- [ x] is in the form of **Named Link - Description, seperated by commas.**
	- [x ] ends with a dot.
