### PR TITLE
Added FistBump project

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 
 ## Projects
 
+- [FistBump Original](https://github.com/eliddell1/FistBump) - Handheld WPA Hash Grabbing Device - proof of concept
+- [FistBump BLE Edition](https://github.com/eliddell1/Project-Blue-Fist/blob/master/README.md) - WPA Hash Grabbing Bluetooth Peripheral / Android App
 - [Mini OONTZ](https://cdn-learn.adafruit.com/downloads/pdf/mini-oontz-3d-printed-midi-controller.pdf) - 3D printed mini MIDI controller.
 - [Power Sniffing Strip](https://hackaday.com/2012/10/04/malicious-raspberry-pi-power-strip-looks-a-bit-scary/) - Enclosure in a power strip, sniffing network data.
 - [Raspberry Pi Erlang Cluster](https://medium.com/@pieterjan_m/erlang-pi2-arm-cluster-vs-xeon-vm-40871d35d356#.bpao66cm8) - Erlang cluster on a Raspberry Pi 2.


### PR DESCRIPTION
Added link to two FistBump Projects.  FistBump is a device for grabbing WPA 4 way handshakes and PMKID hashes for Network Password Strength/Security Auditing.

# Please make sure all below checkboxes have been checked before submitting your PR.
<!-- IMPORTANT:
  If you can check some boxes, please submit your PR first and then
  tick the boxes in the PR description. Don't place x'es in the square brackets [] directly.
  Thank you ✨
-->

- x [ ] I have read and understood the [contribution guidelines](https://github.com/thibmaek/awesome-raspberrypi/blob/master/CONTRIBUTING.md).
- x [ ] This pull request has a descriptive title. *(For example: `Add Raspbian`)*
- The topic I added
	- x [ ] includes a valid (https) link,
	- x [ ] includes a concise and on-topic description,
	- x [ ] mentions if there is only support some devices,
	- x [ ] is not a duplicate,
	- x [ ] has been added at the bottom of the appropriate category,
	- x [ ] is in the form of **Named Link - Description, seperated by commas.**
	- x [ ] ends with a dot.
