### PR TITLE
Add Relayboard Control to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [Raspberry PI Hadoop Cluster](http://www.widriksson.com/raspberry-pi-hadoop-cluster/) - Big Data cluster running on the Raspberry Pi.
 - [RaspiBlitz](https://github.com/rootzoll/raspiblitz) - Fastest and cheapest way to get your own Lightning Node running.
 - [RaspiBolt](https://github.com/Stadicus/guides/tree/master/raspibolt) - Beginner’s Guide to ️⚡Lightning️⚡ on a Raspberry Pi.
+- [Relayboard Control](https://github.com/leinir/relayboard-control) - A Qt application to connect a Waveshare 8-channel relay board to an MQTT server.
 - [Rhasspy](https://rhasspy.readthedocs.io) - Open source, fully offline set of voice assistant services that works well with Home Assistant, Node-RED, MQTT and more.
 - [RPi Motor Library](https://github.com/gavinlyonsrepo/RpiMotorLib) - Python 3 library to connect various motors & servos to the Pi.
 - [RPI tempmon](https://github.com/gavinlyonsrepo/raspberrypi_tempmon) - CPU GPU temperature monitor with various functions such as LED GPIO, Graph output, email, alarm limit, notifications and logging.


### PR DESCRIPTION
Relayboard Control is a Qt application that connects a Waveshare 8-channel relay board to an MQTT server.

# Please make sure all below checkboxes have been checked before submitting your PR.

<!-- IMPORTANT:
  If you can check some boxes, please submit your PR first and then
  tick the boxes in the PR description. Don't place x'es in the square brackets [] directly.
  Thank you ✨
-->

- [x] I have read and understood the [contribution guidelines](https://github.com/thibmaek/awesome-raspberrypi/blob/master/CONTRIBUTING.md).
- [x] This pull request has a descriptive title. *(For example: `Add Raspbian`)*
- The topic I added
  - [x] includes a valid (https) link,
  - [x] includes a concise and on-topic description,
  - [x] mentions if there is only support some devices,
  - [x] is not a duplicate,
  - [x] has been in the correct alphabetical order for its section,
  - [ ] is in the form of **Named Link - Description, separated by commas.**
  - [x] ends with a dot.

Note the un-checked box does not apply as this is a project, not an application.