### PR TITLE
Update Ubuntu distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [RuneAudio](http://www.runeaudio.com/) - Free and open source OS that turns embedded hardware into Hi-Fi music players.
 - [SamplerBox](http://www.samplerbox.org/makeitsoftware) - Drop'n'play sampler: drop .WAV samples on the SD card, and play!
 - [SARPi](http://sarpi.fatdog.nl/index.php?p=sarpi) - Stands for the Slackware ARM on Raspberry Pi.
-- [Snappy Ubuntu Core](https://developer.ubuntu.com/core/get-started/raspberry-pi-2-3) - Official (minimal) Ubuntu distribution for IoT. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)
 - [Twister OS](https://twisteros.com/) - Skinned version of Raspberry Pi OS with preinstalled apps like box86 and Retropie to introduce noobs to Linux and Raspberry Pi. ![Supports Raspberry Pi 3](/media/badges/rpi-3.png)
+- [Ubuntu Core](https://ubuntu.com/download/raspberry-pi-core) - Official (minimal) Ubuntu distribution for IoT. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)
+- [Ubuntu Desktop](https://ubuntu.com/raspberry-pi/desktop) - Ubuntu Desktop distribution for the Raspberry Pi. Supports the Raspberry Pi 4.
 - [Ubuntu MATE](https://ubuntu-mate.org/raspberry-pi/) - Ubuntu distribution for the Raspberry Pi based on MATE desktop. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)
-- [Ubuntu Server](https://www.ubuntu.com/download/iot/raspberry-pi-2-3) - Ubuntu Server distribution for the Raspberry Pi. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png) ![Supports Raspberry Pi 3](/media/badges/rpi-3.png)
+- [Ubuntu Server](https://ubuntu.com/raspberry-pi/server) - Ubuntu Server distribution for the Raspberry Pi. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png) ![Supports Raspberry Pi 3](/media/badges/rpi-3.png)
 - [Volumio](https://volumio.org/) - Headless audiophile music player, designed to play music with the highest possible fidelity.
 - [Windows 10 ARM](https://worproject.ml/) - Community maintained Windows 10 on Raspberry Pi. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png) ![Supports Raspberry Pi 3](/media/badges/rpi-3.png)
 - [Windows 10 IoT Core](https://docs.microsoft.com/nl-nl/windows/iot-core/downloads) - Windows 10 distribution for IoT. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)


### PR DESCRIPTION
This updates the entries for some Ubuntu distributions:

- Snappy Ubuntu Core is now called Ubuntu Core
- Ubuntu Desktop is added
- Ubuntu Server has a new URL

However, I have some questions about the badges:

- I couldn't find a badge for the Raspberry Pi 4 (Ubuntu Desktop only supports the Raspberry Pi 4), so I added this requirement in the description.
- I couldn't find a badge for the Zero 2 W. Ubuntu Server and Core support this model too, how should I add this?
- I noticed Ubuntu Server lists badges for 2+ and 3, while Ubuntu MATE lists 2+. Both distributions support the Raspberry Pi 2, 3 and 4. What does 2+ mean? Raspberry Pi 2 and above? Then 2+ is enough for Ubuntu Server and Ubuntu MATE and 3 should be removed from Ubuntu Server.

<!-- IMPORTANT:
  If you can check some boxes, please submit your PR first and then
  tick the boxes in the PR description. Don't place x'es in the square brackets [] directly.
  Thank you ✨
-->

- [X] I have read and understood the [contribution guidelines](https://github.com/thibmaek/awesome-raspberrypi/blob/master/CONTRIBUTING.md).
- [X] This pull request has a descriptive title. *(For example: `Add Raspbian`)*
- The topic I added
  - [X] includes a valid (https) link,
  - [X] includes a concise and on-topic description,
  - [X] mentions if there is only support some devices,
  - [X] is not a duplicate,
  - [X] has been in the correct alphabetical order for its section,
  - [X] is in the form of **Named Link - Description, separated by commas.**
  - [X] ends with a dot.
