### PR TITLE
Add link for rpi-eth-display

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [Receiving GOES-16 Images on a Raspberry Pi](https://gist.github.com/lxe/c1756ca659c3b78414149a3ea723eae2#file-goes16-rtlsdr-md) - An advanced project to receive weather imagery from the GOES-16 satellite using software defined radio (SDR). 
 - [Relayboard Control](https://github.com/leinir/relayboard-control) - A Qt application to connect a Waveshare 8-channel relay board to an MQTT server.
 - [Rhasspy](https://rhasspy.readthedocs.io) - Open source, fully offline set of voice assistant services that works well with Home Assistant, Node-RED, MQTT and more.
+- [RPi-eth-display](https://pierre-couy.dev/tinkering/2023/03/turning-rpi-into-external-monitor-driver.html) - Open source DisplayLink alternative, ethernet to HDMI adapter. 
 - [RPi Motor Library](https://github.com/gavinlyonsrepo/RpiMotorLib) - Python 3 library to connect various motors & servos to the Pi.
 - [RPI tempmon](https://github.com/gavinlyonsrepo/raspberrypi_tempmon) - CPU GPU temperature monitor with various functions such as LED GPIO, Graph output, email, alarm limit, notifications and logging.
 - [SecPi](https://github.com/SecPi/SecPi) - Raspberry Pi based home alarm system.


### PR DESCRIPTION
This project uses a Raspberry pi to add a 2nd HDMI port to a laptop.

# Please make sure all below checkboxes have been checked before submitting your PR.

<!-- IMPORTANT:
  If you can check some boxes, please submit your PR first and then
  tick the boxes in the PR description. Don't place x'es in the square brackets [] directly.
  Thank you ✨
-->

- [x] I have read and understood the [contribution guidelines](https://github.com/thibmaek/awesome-raspberrypi/blob/master/CONTRIBUTING.md).
- [x] This pull request has a descriptive title. *(For example: `Add Raspbian`)*
- The topic I added
  - [x] includes a valid (https) link,
  - [x] includes a concise and on-topic description,
  - [x] mentions if there is only support some devices,
  - [x] is not a duplicate,
  - [x] has been in the correct alphabetical order for its section,
  - [x] is in the form of **Named Link - Description, separated by commas.**
  - [x] ends with a dot.
