### PR TITLE
Add PI connect to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [TorTiPi](https://github.com/r0hi7/tortipi) - Shell script to automate the task of converting Raspberry Pi into a tor based wifi hotspot.
 - [WebStation SYSMON](https://github.com/t0xic0der/sysmon) - An intuitive remotely-accessible system performance monitoring and task management tool for servers  and headless Raspberry Pi setups.
 - [WiFi config generator](https://steveedson.co.uk/tools/wpa/) - Simple tool to generate wpa_supplicant.conf files with wifi settings
+- [Pi Connect](https://www.raspberrypi.com/software/connect/) - {BETA} Official tool to remotely connect to your raspberry pi device (supports screen sharing, SSH, remote control) 
 
 ## Projects
 


### PR DESCRIPTION
therre is a New Web tool made by the raspberry pi devs currently in beta but avaliable publically added to tools since there isn't a app for it that i know of

# Please make sure all below checkboxes have been checked before submitting your PR.

<!-- IMPORTANT:
  If you can check some boxes, please submit your PR first and then
  tick the boxes in the PR description. Don't place x'es in the square brackets [] directly.
  Thank you ✨
-->

- [x] I have read and understood the [contribution guidelines](https://github.com/thibmaek/awesome-raspberrypi/blob/main/CONTRIBUTING.md).
- [x] This pull request has a descriptive title. *(For example: `Add Raspbian`)*
- The topic I added
  - [x] includes a valid (https) link,
  - [x] includes a concise and on-topic description,
  - [x] mentions if there is only support some devices,
  - [x] is not a duplicate,
  - [ ] has been in the correct alphabetical order for its section,
  - [x] is in the form of **Named Link - Description, separated by commas.**
  - [ ] ends with a dot.
