### PR TITLE
Remove FabScan

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [DietPi](https://github.com/Fourdee/DietPi) - Minimal image designed to fit on a 2GB SD card, with tons of configurable settings and scripts.
 - [DroneBridge](https://github.com/seeul8er/DroneBridge) - A WifiBroadcast extension to make for a real alternative to DJI Lightbridge and other similar systems. ![Supports Raspberry Pi 3](/media/badges/rpi-3.png)
 - [EZ-WifiBroadcast](https://github.com/bortek/EZ-WifiBroadcast/wiki) - Affordable Wireless Digital HD Video Transmission made easy. ![Supports Raspberry Pi 3](/media/badges/rpi-3.png) ![Supports Raspberry Pi Zero](/media/badges/rpi-0.png)
-- [FabScanPi](https://mariolukas.github.io/FabScanPi-Server/) - FabScanPi is an open source 3D laser scanner using the Raspberry Pi Camera Module. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)
 - [Fedora](https://fedoraproject.org/wiki/Raspberry_Pi#Preparing_the_SD_card) - Linux Fedora distribution built for the Pi. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)
 - [FreeBSD](https://wiki.freebsd.org/arm/Raspberry%20Pi) - FreeBSD is an advanced computer operating system used to power modern servers, desktops, and embedded platforms.
 - [FreedomBox](https://www.freedombox.org) - FreedomBox is a private home server for non-experts. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)


### PR DESCRIPTION
# Please make sure all below checkboxes have been checked before submitting your PR.

FabScan is now only available as a server instance. No OS image, link is dead

https://github.com/mariolukas/FabScanPi-Server/tree/master

- [x] I have read and understood the [contribution guidelines](https://github.com/thibmaek/awesome-raspberrypi/blob/main/CONTRIBUTING.md).
- [x] This pull request has a descriptive title. *(For example: `Add Raspbian`)*
- The topic I added
  - [x] includes a valid (https) link,
  - [x] includes a concise and on-topic description,
  - [x] mentions if there is only support some devices,
  - [x] is not a duplicate,
  - [x] has been in the correct alphabetical order for its section,
  - [x] is in the form of **Named Link - Description, separated by commas.**
  - [x] ends with a dot.
