### PR TITLE
Add idle-less to Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [Harry Potter and the real life Daily Prophet](https://www.raspberrypi.org/blog/harry-potter-and-the-real-life-daily-prophet/) - Display mimicking the Daily Prophet from Harry Potter using a 7" Raspberry Pi display.
 - [Haven](https://github.com/havenweb/haven) - Host a private blog on your Rasperry Pi instead of using Facebook.
 - [Hearing aid prototoype](https://github.com/m-r-s/hearingaid-prototype) - A Raspberry Pi powered prototype of a hearing aid. ![Supports Raspberry Pi 3](/media/badges/rpi-3.png)
+- [idle-less](https://github.com/tvup/idle-less) - Docker-based nginx reverse proxy that wakes sleeping servers via Wake-on-LAN, ideal for energy-saving Raspberry Pi homelabs.
 - [Internet Chronometer](https://github.com/rothman857/chronometer) - Turn your Raspberry Pi in to an Internet Chronometer.
 - [Jasper](https://jasperproject.github.io/) - Flexible open source personal assistant.
 - [Kubernetes on ARM](https://github.com/luxas/kubernetes-on-arm) - Get your ARM device up and running Kubernetes in less than ten minutes.


### PR DESCRIPTION
Adding **idle-less** to the Projects section.

idle-less is a Docker-based nginx reverse proxy with integrated Wake-on-LAN support. When traffic hits a domain and the backend server is sleeping, it sends a WoL magic packet, shows a waiting page, and redirects when the server comes online. Ideal for Raspberry Pi homelabs where energy savings matter.

- **GitHub:** https://github.com/tvup/idle-less
- **License:** MIT
- **Platforms:** AMD64, ARM64 (runs great on Raspberry Pi)
- **Category:** Networking / Power management

This tool helps Raspberry Pi users run energy-efficient homelabs by automatically waking servers only when needed.