### PR TITLE
Add ClawCare - AI health monitoring agent for Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [Reddit Projects](https://www.reddit.com/r/RASPBERRY_PI_PROJECTS)
 - [Reddit](https://www.reddit.com/r/raspberry_pi)
 - [StackExchange](https://raspberrypi.stackexchange.com/)
+- [ClawCare](https://www.clawcare.net) - AI health agent that monitors your family 24/7 on Raspberry Pi. Connects BLE/WiFi health devices, proactive health insights, automated doctor booking.
 
 ### Contributing
 


### PR DESCRIPTION
Adding [ClawCare](https://www.clawcare.net) — an AI health agent that runs 24/7 on Raspberry Pi. It connects BLE/WiFi health devices (scales, BP monitors, wearables), provides proactive health monitoring, and can auto-book doctor appointments. Built on the OpenClaw platform, all data stays local for privacy.