### PR TITLE
Add amneziawg-installer to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 ## Tools
 
 - [Alpha](https://github.com/farjump/raspberry-pi) - Remotely load, debug and test bare-metal programs using GDB with this system-level GDB server.
+- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) - One-command installer for AmneziaWG 2.0, a DPI-resistant WireGuard fork, with prebuilt kernel modules for Raspberry Pi 3/4/5.
 - [ApplePi Baker](https://www.tweaking4all.com/hardware/raspberry-pi/applepi-baker-v2/) - macOS application to easily install/backup/restore images onto an SD card.
 - [Armbian Imager](https://imager.armbian.com) - An open-source imaging tool that makes installing Armbian OS effortless.
 - [Atlas toolkit](https://github.com/epeios-q37/atlas-python) - Very lightweight and easy to install toolkit to write in Python single-page web applications to pilot your RPi, without having to install a web server.


### PR DESCRIPTION
# Please make sure all below checkboxes have been checked before submitting your PR.

- [x] I have read and understood the [contribution guidelines](https://github.com/thibmaek/awesome-raspberrypi/blob/main/CONTRIBUTING.md).
- [x] This pull request has a descriptive title. *(For example: `Add Raspbian`)*
- The topic I added
  - [x] includes a valid (https) link,
  - [x] includes a concise and on-topic description,
  - [x] mentions if there is only support some devices,
  - [x] is not a duplicate,
  - [x] has been in the correct alphabetical order for its section,
  - [x] is in the form of **Named Link - Description, separated by commas.**
  - [x] ends with a dot.

Adds [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) to the Tools section.

It installs AmneziaWG 2.0 (a WireGuard fork with packet obfuscation that bypasses DPI) in one bash command on Ubuntu or Debian. v5.9.0 adds prebuilt kernel modules for Raspberry Pi 3/4/5, so the Pi doesn't have to compile the kernel module itself. MIT license.