### PR TITLE
Add Raspberry Pi Docker Compose Generator to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [Orangetool](https://github.com/Moduland/Orangetool) - Control functions for Single-Board computers in Python.
 - [Pi Temperature Exporter](https://github.com/s-nagaev/pi-temperature-exporter) - a CPU and GPU temperature exporter for Prometheus consumption.
 - [pi-gen](https://github.com/RPi-Distro/pi-gen) - Tool used to create the raspberrypi.org Raspbian images. This can be used to create your own custom images with specific packages installed, etc.
+- [Raspberry Pi Docker Compose Generator](https://raspberry.tips/en/raspberry-pi-docker-compose-generator) - Web-based one-click generator to easily configure and deploy smart home and self-hosted Docker containers on the Raspberry Pi without YAML syntax errors.
 - [Raspberry Pi SD Card Lifespan Calculator](https://raspberry.tips/sd-karten-lebensdauer-rechner-wie-lange-haelt-dein-speicher) - Interactive tool to estimate when your SD card will fail based on P/E cycles and Write Amplification Factor (WAF).
 - [Pieman](https://github.com/tolstoyevsky/pieman) - Script for creating custom images based on Raspbian, Devuan, Ubuntu and Alpine Linux.
 - [PiKISS](https://github.com/jmcerrejon/PiKISS) - A bunch of scripts with menu to make your life easier.
@@ -316,6 +317,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [How To Make a Raspberry Pi Turn on a Lamp with iBeacon™ Technology](http://developer.radiusnetworks.com/2014/04/27/how-to-make-a-raspberry-pi-turn-on-a-lamp-with-an-ibeacon.html) - Good beginners-guide to working with Beacon technology.
 - [Moonlight](https://github.com/irtimmer/moonlight-embedded) - Nvidia GameStream implementation to stream your full collection of Steam games from desktop to the Raspberry Pi.
 - [Raspberry Pi 5 SSD Boot Guide](https://raspberry.tips/raspberry-pi-5-zubehoer-test) - Comprehensive guide on upgrading RPi 5 with NVMe SSDs, including benchmarks and hardware compatibility tests (2026 update).
+- [Raspberry Pi GPIO Pinout Guide](https://raspberry.tips/raspberry-pi-gpio-pinout) - Comprehensive guide for all Pi models, including the new Pi 5 and 5V-tolerance updates.
 - [Raspbereum](https://github.com/jim380/Raspbereum) - Run your own Ethereum node on a Raspberry Pi.
 - [Raspberry Pi Game Console](https://lifehacker.com/how-to-turn-your-raspberry-pi-into-a-retro-game-console-498561192) - How to Build a Raspberry Pi Retro Game Console for $35.
 - [Raspberry Pi login with SSH keys](https://thibmaek.com/posts/raspberry-pi-login-with-ssh-keys) - Password-less login for ssh sessions on the Raspberry Pi.


### PR DESCRIPTION
Hi! I'd like to contribute the English version of the [Raspberry Pi Docker Compose Generator](https://raspberry.tips/en/raspberry-pi-docker-compose-generator) to the Tools section. It's a free web-based utility that helps users to visually configure and generate error-free `docker-compose.yml` stacks for their self-hosted projects (like Pi-hole, Home Assistant, etc.) without struggling with YAML syntax.

Thanks for maintaining this awesome list!