### PR TITLE
Add TimeNest to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [StreamPi](https://stream-pi.com/) - A robust alternative to the Elgato Stream Deck, that can launch apps, scripts, websites and control applications like OBS.
 - [TelePi](https://github.com/besoeasy/telepi) - Telepi allows you to monitor and control your Raspberry Pi via Telegram featuring file downloads, system monitoring, network insights, speed tests, and the ability to open web tunnels.
 - [TeslaCam](https://github.com/LelandSindt/teslacam) - Project utilizing a Raspberry Pi Zero W for USB Mass storage emulation and a PiJuice to collect and archive TeslaCam video. ![Supports Raspberry Pi Zero](/media/badges/rpi-0.png)
+- [TimeNest](https://github.com/momenbasel/timenest) - Turns a Raspberry Pi with a USB 3 drive into a Time Capsule replacement for every Mac on your LAN. Three-container Docker stack (Samba `vfs_fruit`, Avahi for Bonjour, FastAPI admin UI) with per-user Time Machine quotas and Prometheus metrics. ![Supports Raspberry Pi 2+](/media/badges/rpi-2+.png)
 - [Ultimate DNS Shield](https://github.com/cherifon/Ultimate-DNS-Shield) - Self-hosted recursive DNS server using Pi-hole, Unbound and Docker on Raspberry Pi 4.
 - [USB Proxy](https://github.com/AristoChen/usb-proxy) - A USB man-in-the-middle project that allow users to monitor and modify USB packets flow between host and device.
 - [Vinyl Shelf Finder](https://valentingalea.github.io/vinyl-shelf-finder/) - Uses a tilt & pan laser to find a record in a record collection.


### PR DESCRIPTION
Hi, adding [TimeNest](https://github.com/momenbasel/timenest) to the Projects list.

TimeNest turns a Raspberry Pi (4 or 5, ideally with a USB 3 SSD) into a network Time Machine target for every Mac on the LAN. It is a three-container Docker stack:

- Samba 4.18 with \`vfs_fruit\` for per-user TM shares
- Avahi for Bonjour discovery as a \`TimeCapsule8,119\`
- FastAPI admin UI with quotas, SMART, and Prometheus metrics

Benchmarks on a Pi 5 + USB 3 NVMe: 100 GB first backup in 21 minutes at 79 MB/s sustained. Multi-arch images cover \`linux/arm64\` and \`linux/arm/v7\`.

MIT licensed, no telemetry, single \`docker compose up -d\`. Repo: https://github.com/momenbasel/timenest

Happy to tweak badges or wording.