### PR TITLE
Add GPIO Pinout tool + update SD card calculator to English URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [Orangetool](https://github.com/Moduland/Orangetool) - Control functions for Single-Board computers in Python.
 - [Pi Temperature Exporter](https://github.com/s-nagaev/pi-temperature-exporter) - a CPU and GPU temperature exporter for Prometheus consumption.
 - [pi-gen](https://github.com/RPi-Distro/pi-gen) - Tool used to create the raspberrypi.org Raspbian images. This can be used to create your own custom images with specific packages installed, etc.
-- [Raspberry Pi SD Card Lifespan Calculator](https://raspberry.tips/sd-karten-lebensdauer-rechner-wie-lange-haelt-dein-speicher) - Interactive tool to estimate when your SD card will fail based on P/E cycles and Write Amplification Factor (WAF).
+- [Raspberry Pi GPIO Pinout](https://raspberry.tips/en/raspberry-pi-gpio-pinout) - Interactive pinout reference for all 40 GPIO pins with BCM numbers, functions, voltage specs, and HAT overlays. Updated for Pi 5 (RP1 controller).
+- [Raspberry Pi SD Card Lifespan Calculator](https://raspberry.tips/en/calculate-raspberry-pi-sd-card-lifespan-test-now) - Interactive tool to estimate when your SD card will fail based on P/E cycles and Write Amplification Factor (WAF).
 - [Pieman](https://github.com/tolstoyevsky/pieman) - Script for creating custom images based on Raspbian, Devuan, Ubuntu and Alpine Linux.
 - [PiKISS](https://github.com/jmcerrejon/PiKISS) - A bunch of scripts with menu to make your life easier.
 - [Pimod](https://github.com/Nature40/pimod) - Reconfigure Raspberry Pi images with an easy, Docker-like configuration file.


### PR DESCRIPTION
﻿## Changes

- **Add** `Raspberry Pi GPIO Pinout` to the Tools section — interactive reference for all 40 GPIO pins with BCM numbers, functions, voltage specs, and HAT overlays. Covers Pi 5 (RP1 controller) where pin access changed significantly vs. Pi 4.

- **Update** `Raspberry Pi SD Card Lifespan Calculator` link from the German URL to the English version (`/en/calculate-raspberry-pi-sd-card-lifespan-test-now`).

Both tools are from raspberry.tips, which is already represented in the list.
