### PR TITLE
Add DCS-BIOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The complete collection of (consumer) Raspberry Pi models consist of:
 - [CocktailMaker](https://github.com/alex9849/pi-cocktail-maker) - An advanced cocktail making machine that can be controlled via browser and touchscreen.
 - [CocktailTDI](https://github.com/SimonWaldherr/CocktailTDI) - Another cocktail machine (powered by Raspberry Pi 4, Golang, a pneumatic pump and valves).
 - [Coder for Raspberry Pi](http://googlecreativelab.github.io/coder/) - A open source project by Googlers to turn a Raspberry Pi into a simple, tiny, personal web server and web-based development environment.
+- [DCS-BIOS](https://github.com/DCS-Skunkworks/dcs-bios) - Exports DCS World cockpit data (switches, lights, displays) over serial/UDP to Arduino, ESP32, or Raspberry Pi for physical panel builds.
 - [Display_Lib_RPI](https://github.com/gavinlyonsrepo/Display_Lib_RPI) - A shared installable C++ Library to connect various electronic displays to Raspberry Pi single board computers.
 - [DIY Arcade Machine](https://github.com/SimonWaldherr/DIY-Arcade-Machine) - A retro style arcade machine, based on a Raspberry Pi Pico, a Hub75 LED matrix and some other stuff (Wii Nunchucks, 3D printed parts, ...) 
 - [DIY USB Rubber Ducky](https://hackaday.io/project/17598-diy-usb-rubber-ducky) - Raspberry Pi Zero Rubber Ducky recognized as a USB HID by just about anything with a USB port, thus allowing you to run custom scripts as if it were a keyboard. ![Supports Raspberry Pi Zero](/media/badges/rpi-0.png)


### PR DESCRIPTION
Adds [DCS-BIOS](https://github.com/DCS-Skunkworks/dcs-bios) to the Projects section.

DCS-BIOS exports cockpit state from DCS World (switches, lights, displays) over serial or UDP to microcontrollers like Arduino, ESP32, or Raspberry Pi. It's widely used in the flight sim community to build physical cockpit panels with real buttons, LEDs, and displays.

Placed alphabetically between "Coder for Raspberry Pi" and "Display_Lib_RPI".

## Checklist
- [x] The link is an HTTPS link
- [x] Added in alphabetical order
- [x] Description is a single sentence
- [x] Only README.md was modified
